### PR TITLE
Fix: Model card config yaml output

### DIFF
--- a/flow_merge/lib/utils.py
+++ b/flow_merge/lib/utils.py
@@ -57,18 +57,19 @@ def generate_model_card(merge_config: MergeConfig, model_name: str = None):
         for model in model_path_list:
             models += "\t- " + model + "\n"
 
-    config = merge_config.data
-
     # tags
     tags = ["flow-merge", "merge"]
 
+    config = merge_config.data.model_dump(exclude={'hf_hub_settings': {'token'}}, 
+                                          exclude_unset=True)
+    config["method"] = config["method"].value
     metadata = yaml.dump({"tags": tags, "library_name": "transformers"})
 
     fmt_card = MODEL_CARD_TEMPLATE.format(
         metadata=metadata,
         model_name=model_name,
         models=models,
-        config=yaml.dump(config, sort_keys=False),
+        config=yaml.dump(config, indent=2, sort_keys=False, default_flow_style=False),
     )
 
     with open(


### PR DESCRIPTION

Previous model card in issue https://github.com/flowritecom/flow-merge/issues/10


- Dropped `hf_hub_settings` key `token` from being exported to the model card
```
config = merge_config.data.model_dump(exclude={'hf_hub_settings': {'token'}}, exclude_unset=True)
config["method"] = config["method"].value
```

- Added default_flow_style = False because 
> If you want collections to be always serialized in the block style, set the parameter default_flow_style of dump() to False.
([more](https://pyyaml.org/wiki/PyYAMLDocumentation))
- Fixed model card below:


```
---
library_name: transformers
tags:
- flow-merge
- merge

---
# test-model-card

This model is the result of merge of the following models made with flow-merge:

- Base model:
	- Qwen/Qwen1.5-0.5B
- Models:
	- Qwen/Qwen1.5-0.5B-chat
	- minghaowu/Qwen1.5-0.5B-OpenHermes-2.5


## flow-merge config

The following configuration was used to merge the models:

```yaml
base_model: Qwen/Qwen1.5-0.5B
models:
- path_or_id: Qwen/Qwen1.5-0.5B
  weight: 0.5
- path_or_id: Qwen/Qwen1.5-0.5B-chat
  weight: 0.3
- path_or_id: minghaowu/Qwen1.5-0.5B-OpenHermes-2.5
  weight: 0.3
method: dare-ties-merging
method_global_parameters:
  scaling_coefficient: 0.7
  normalize: false
  p: 0.7
directory_settings:
  cache_dir: null
  local_dir: ./models
  output_dir: ./ties_merging_model
hf_hub_settings:
  trust_remote_code: false

```
```